### PR TITLE
Add ingress relation support and corresponding integration test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@update-charming-actions
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@update-charming-actions
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,3 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 type: charm
 bases:
   - build-on:

--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,3 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 options: {}

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -1,0 +1,562 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v1.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v1.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+
+import logging
+import socket
+import typing
+from typing import Any, Dict, Optional, Tuple, Union
+
+import yaml
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 12
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+
+try:
+    import jsonschema
+
+    DO_VALIDATION = True
+except ModuleNotFoundError:
+    log.warning(
+        "The `ingress` library needs the `jsonschema` package to be able "
+        "to do runtime data validation; without it, it will still work but validation "
+        "will be disabled. \n"
+        "It is recommended to add `jsonschema` to the 'requirements.txt' of your charm, "
+        "which will enable this feature."
+    )
+    DO_VALIDATION = False
+
+INGRESS_REQUIRES_APP_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "model": {"type": "string"},
+        "name": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "string"},
+        "strip-prefix": {"type": "string"},
+    },
+    "required": ["model", "name", "host", "port"],
+}
+
+INGRESS_PROVIDES_APP_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ingress": {"type": "object", "properties": {"url": {"type": "string"}}},
+    },
+    "required": ["ingress"],
+}
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict  # py35 compat
+
+# Model of the data a unit implementing the requirer will need to provide.
+RequirerData = TypedDict(
+    "RequirerData",
+    {"model": str, "name": str, "host": str, "port": int, "strip-prefix": bool},
+    total=False,
+)
+# Provider ingress data model.
+ProviderIngressData = TypedDict("ProviderIngressData", {"url": str})
+# Provider application databag model.
+ProviderApplicationData = TypedDict("ProviderApplicationData", {"ingress": ProviderIngressData})  # type: ignore
+
+
+def _validate_data(data, schema):
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    if not DO_VALIDATION:
+        return
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event):
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event):
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event):
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__ = ()  # type: Tuple[str, ...]
+    __optional_kwargs__ = {}  # type: Dict[str, Any]
+
+    @classmethod
+    def __attrs__(cls):
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self):
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "port", "host", "strip_prefix")
+
+    if typing.TYPE_CHECKING:
+        name = None  # type: Optional[str]
+        model = None  # type: Optional[str]
+        port = None  # type: Optional[str]
+        host = None  # type: Optional[str]
+        strip_prefix = False  # type: bool
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self._get_requirer_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data["name"],
+                data["model"],
+                data["port"],
+                data["host"],
+                data.get("strip-prefix", False),
+            )
+
+    def _handle_relation_broken(self, event):
+        self.on.data_removed.emit(event.relation)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation):
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+
+    def _get_requirer_data(self, relation: Relation) -> RequirerData:  # type: ignore
+        """Fetch and validate the requirer's app databag.
+
+        For convenience, we convert 'port' to integer.
+        """
+        if not relation.app or not relation.app.name:  # type: ignore
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return {}
+
+        databag = relation.data[relation.app]
+        remote_data = {}  # type: Dict[str, Union[int, str]]
+        for k in ("port", "host", "model", "name", "mode", "strip-prefix"):
+            v = databag.get(k)
+            if v is not None:
+                remote_data[k] = v
+        _validate_data(remote_data, INGRESS_REQUIRES_APP_SCHEMA)
+        remote_data["port"] = int(remote_data["port"])
+        remote_data["strip-prefix"] = bool(remote_data.get("strip-prefix", False))
+        return typing.cast(RequirerData, remote_data)
+
+    def get_data(self, relation: Relation) -> RequirerData:  # type: ignore
+        """Fetch the remote app's databag, i.e. the requirer data."""
+        return self._get_requirer_data(relation)
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            return bool(self._get_requirer_data(relation))
+        except DataValidationError as e:
+            log.warning("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _provided_url(self, relation: Relation) -> ProviderIngressData:  # type: ignore
+        """Fetch and validate this app databag; return the ingress url."""
+        if not relation.app or not relation.app.name or not self.unit.is_leader():  # type: ignore
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return typing.cast(ProviderIngressData, {})  # noqa
+
+        # fetch the provider's app databag
+        raw_data = relation.data[self.app].get("ingress")
+        if not raw_data:
+            raise RuntimeError("This application did not `publish_url` yet.")
+
+        ingress: ProviderIngressData = yaml.safe_load(raw_data)
+        _validate_data({"ingress": ingress}, INGRESS_PROVIDES_APP_SCHEMA)
+        return ingress
+
+    def publish_url(self, relation: Relation, url: str):
+        """Publish to the app databag the ingress url."""
+        ingress = {"url": url}
+        ingress_data = {"ingress": ingress}
+        _validate_data(ingress_data, INGRESS_PROVIDES_APP_SCHEMA)
+        relation.data[self.app]["ingress"] = yaml.safe_dump(ingress)
+
+    @property
+    def proxied_endpoints(self):
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results = {}
+
+        for ingress_relation in self.relations:
+            assert (
+                ingress_relation.app
+            ), "no app in relation (shouldn't happen)"  # for type checker
+            results[ingress_relation.app.name] = self._provided_url(ingress_relation)
+
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url = None  # type: Optional[str]
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            relation_name: the name of the relation endpoint to bind to (defaults to `ingress`);
+                relation must be of interface type `ingress` and have "limit: 1")
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            strip_prefix: configure Traefik to strip the path prefix.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data(event.relation)
+
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event):
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(event.relation)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event):
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        for relation in self.relations:
+            self._publish_auto_data(relation)
+
+    def is_ready(self):
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.warning("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self, relation: Relation):
+        if self._auto_data and self.unit.is_leader():
+            host, port = self._auto_data
+            self.provide_ingress_requirements(host=host, port=port)
+
+    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int):
+        """Publishes the data that Traefik needs to provide ingress.
+
+        NB only the leader unit is supposed to do this.
+
+        Args:
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            port: the port of the service (required)
+        """
+        # get only the leader to publish the data since we only
+        # require one unit to publish it -- it will not differ between units,
+        # unlike in ingress-per-unit.
+        assert self.unit.is_leader(), "only leaders should do this."
+        assert self.relation, "no relation"
+
+        if not host:
+            host = socket.getfqdn()
+
+        data = {
+            "model": self.model.name,
+            "name": self.app.name,
+            "host": host,
+            "port": str(port),
+        }
+
+        if self._strip_prefix:
+            data["strip-prefix"] = "true"
+
+        _validate_data(data, INGRESS_REQUIRES_APP_SCHEMA)
+        self.relation.data[self.app].update(data)
+
+    @property
+    def relation(self):
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            raw = relation.data.get(relation.app, {}).get("ingress")
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not raw:
+            return None
+
+        ingress: ProviderIngressData = yaml.safe_load(raw)
+        _validate_data({"ingress": ingress}, INGRESS_PROVIDES_APP_SCHEMA)
+        return ingress["url"]
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = self._stored.current_url or self._get_url_from_relation_data()  # type: ignore
+        assert isinstance(data, (str, type(None)))  # for static checker
+        return data

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 r"""# Interface Library for ingress.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,17 +1,13 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 name: flask-k8s
-
 display-name: Flask
-
 summary: Turn any Flask application into a charm.
-
 description: Flask charm can turn any Flask application into a charm.
-
 docs: ""
-
 issues: https://github.com/canonical/flask-k8s-operator/issues
-
+source: https://github.com/canonical/flask-k8s-operator
 maintainers:
   - launchpad.net/~canonical-is-devops
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 name: flask-k8s
 
 display-name: Flask

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,3 +21,8 @@ resources:
   flask-app-image:
     type: oci-image
     description: Flask application image.
+
+requires:
+  ingress:
+    interface: ingress
+    limit: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ skips = ["*/*test.py", "*/test_*.py"]
 
 [tool.mypy]
 ignore_missing_imports = true
-explicit_package_bases = true
-namespace_packages = true
 check_untyped_defs = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ exclude_dirs = ["/venv/"]
 
 [tool.bandit.assert_used]
 skips = ["*/*test.py", "*/test_*.py"]
+
+[tool.mypy]
+ignore_missing_imports = true
+explicit_package_bases = true
+namespace_packages = true
+check_untyped_defs = true

--- a/sample_rock/rockcraft.yaml
+++ b/sample_rock/rockcraft.yaml
@@ -1,3 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 name: flask-app
 summary: A flask sample app
 description: OCI image for the sample flask app

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 import logging
 import typing
 
+from charms.traefik_k8s.v1.ingress import IngressPerAppRequirer
 from ops.charm import CharmBase, ConfigChangedEvent
 from ops.main import main
 from ops.model import ActiveStatus
@@ -25,6 +26,12 @@ class FlaskCharm(CharmBase):
         """
         super().__init__(*args)
         self.framework.observe(self.on.config_changed, self.config_service)
+        self.ingress = IngressPerAppRequirer(
+            self,
+            port=8000,
+            host=f"{self.app.name}-endpoints.{self.model.name}.svc.cluster.local",
+            strip_prefix=True,
+        )
 
     def config_service(self, event: ConfigChangedEvent) -> None:
         """Configure the flask pebble service layer.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,10 +3,22 @@
 
 """Fixtures for flask charm integration tests."""
 
+import asyncio
 import json
 
+import juju
+import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
+
+
+@pytest_asyncio.fixture(scope="module", name="model")
+async def model_fixture(ops_test: OpsTest) -> juju.model.Model:
+    """Provide current test model."""
+    assert ops_test.model
+    model_config = {"logging-config": "<root>=INFO;unit=DEBUG"}
+    await ops_test.model.set_config(model_config)
+    return ops_test.model
 
 
 @pytest_asyncio.fixture(scope="module", name="get_unit_ips")
@@ -28,3 +40,20 @@ async def fixture_get_unit_ips(ops_test: OpsTest):
         )
 
     yield _get_unit_ips
+
+
+@pytest_asyncio.fixture(scope="module", name="flask_app")
+async def flask_app_fixture(
+    ops_test: OpsTest,
+    pytestconfig: pytest.Config,
+    model: juju.model.Model,
+):
+    """Build and deploy the flask charm."""
+    app_name = "flask-k8s"
+    charm = await ops_test.build_charm(".")
+    resources = {"flask-app-image": pytestconfig.getoption("--flask-app-image")}
+    deploy_result = await asyncio.gather(
+        model.deploy(charm, resources=resources, application_name=app_name, series="jammy"),
+        model.wait_for_idle(apps=[app_name], raise_on_blocked=True),
+    )
+    return deploy_result[0]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import pytest_asyncio
 import requests
+from ops.model import ActiveStatus, Application
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -41,3 +42,40 @@ async def test_flask_is_up(flask_app, get_unit_ips):
         response = requests.get(f"http://{unit_ip}:8000", timeout=5)
         assert response.status_code == 200
         assert "Hello, World!" in response.text
+
+
+async def test_with_ingress(
+    ops_test: OpsTest,
+    flask_app: Application,
+    get_unit_ips,
+):
+    """
+    arrange: build and deploy the flask charm.
+    act: deploy the ingress, configure it and relate it to the charm.
+    assert: requesting the charm through traefik should return a correct response
+    """
+    traefik_app = await ops_test.model.deploy("traefik-k8s", trust=True)
+    await ops_test.model.wait_for_idle()
+
+    external_hostname = "juju.local"
+    await traefik_app.set_config(
+        {
+            "external_hostname": external_hostname,
+            "routing_mode": "subdomain",
+        }
+    )
+    await ops_test.model.wait_for_idle()
+
+    await ops_test.model.add_relation(flask_app.name, traefik_app.name),
+
+    # mypy doesn't see that ActiveStatus has a name
+    await ops_test.model.wait_for_idle(status=ActiveStatus.name)  # type: ignore
+
+    traefik_ip = next(await get_unit_ips(traefik_app.name))
+    response = requests.get(
+        f"http://{traefik_ip}",
+        headers={"Host": f"{ops_test.model_name}-{flask_app.name}.{external_hostname}"},
+        timeout=5,
+    )
+    assert response.status_code == 200
+    assert "Hello, World!" in response.text

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,10 +12,8 @@ from charm import FlaskCharm
 @pytest.fixture(name="harness")
 def harness_fixture():
     """Ops testing framework harness fixture."""
-    ops.testing.SIMULATE_CAN_CONNECT = True
     harness = ops.testing.Harness(FlaskCharm)
 
     yield harness
 
     harness.cleanup()
-    ops.testing.SIMULATE_CAN_CONNECT = False


### PR DESCRIPTION
Adds the `ingress` interface support and the corresponding integration test.

We take as granted that the flask app will always be on port 8000.