### PR TITLE
Remove workaround in rockcraft.yaml

### DIFF
--- a/sample_rock/rockcraft.yaml
+++ b/sample_rock/rockcraft.yaml
@@ -20,11 +20,6 @@ parts:
       - gunicorn
     python-requirements:
       - requirements.txt
-    override-prime: |
-      craftctl default
-      # We remove the standard executable to have only /bin/python3 in our PATH
-      # Related to https://github.com/canonical/rockcraft/issues/242
-      rm -f "$CRAFT_PRIME/usr/bin/python3"
   flask-app:
     plugin: dump
     source: .


### PR DESCRIPTION
This removes the workaround used for the python part in rockcraft (it was fixed with https://github.com/canonical/rockcraft/issues/242)