### PR TITLE
Add sentinel image and sentinel image check

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,3 +7,4 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
+    modules: '["test_charm", "test_sentinel"]'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,4 +7,5 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
-    modules: '["test_charm", "test_sentinel"]'
+    with:
+      modules: '["test_charm", "test_sentinel"]'

--- a/sentinel.Dockerfile
+++ b/sentinel.Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:latest
+
+RUN cp /dev/null /null
+
+FROM scratch
+
+COPY --from=0 /null /null

--- a/sentinel.Dockerfile
+++ b/sentinel.Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:latest
-
-RUN cp /dev/null /null
-
-FROM scratch
-
-COPY --from=0 /null /null

--- a/sentinel_rock/rockcraft.yaml
+++ b/sentinel_rock/rockcraft.yaml
@@ -1,0 +1,17 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: sentinel
+summary: A sentinel image acts as a placeholder for the OCI image resource on CharmHub.
+description: A sentinel image acts as a placeholder for the OCI image resource on CharmHub.
+version: "1.0"
+base: bare
+build-base: ubuntu:22.04
+license: Apache-2.0
+platforms:
+  amd64:
+
+parts:
+  create-sentinel-file:
+    plugin: nil
+    overlay-script: |
+      touch $CRAFT_OVERLAY/null

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utilities for identifying the use of sentinel image in Flask-K8s charm deployment.
+
+The Flask-K8s charm operates under a 'Bring Your Own Container Image' mode, requiring users
+to supply a container image for their Flask application. However, to fulfill CharmHub's
+requirements, a sentinel image is provided as a placeholder.
+
+Functions in this module assist in determining if the Flask application container image
+deployed is the sentinel image. If so, the charm can trigger a user-friendly error message.
+"""
+
+from ops import CharmBase
+
+from constants import FLASK_CONTAINER_NAME
+
+
+class Sentinel:  # pylint: disable=too-few-public-methods
+    """A helper class for checking if the deployed Flask application image is a sentinel image."""
+
+    def __init__(self, charm: CharmBase):
+        """Initialize the Sentinel object.
+
+        Args:
+            charm: associated charm object.
+        """
+        self._charm = charm
+
+    def is_sentinel_image(self) -> bool:
+        """Check if the Flask application container is using the sentinel image.
+
+        Returns: True if the sentinel image is being used, False otherwise.
+        """
+        container = self._charm.unit.get_container(FLASK_CONTAINER_NAME)
+        if container.can_connect():
+            return container.exists("/null")
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,4 @@
 def pytest_addoption(parser):
     """Define some command line options for integration and unit tests."""
     parser.addoption("--flask-app-image", action="store")
+    parser.addoption("--sentinel-image", action="store")

--- a/tests/integration/test_sentinel.py
+++ b/tests/integration/test_sentinel.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for flask-k8s charm sentinel check."""
+
+from juju.model import Model
+from pytest import Config
+from pytest_operator.plugin import OpsTest
+
+
+async def test_sentinel_check(
+    pytestconfig: Config,
+    ops_test: OpsTest,
+    model: Model,
+):
+    """
+    arrange: none.
+    act: build and deploy the flask-k8s charm with sentinel image as the flask-app-image.
+    assert: flask-k8s charm should enter blocked state.
+    """
+    charm = await ops_test.build_charm(".")
+    resources = {
+        "flask-app-image": pytestconfig.getoption("--sentinel-image"),
+        "statsd-prometheus-exporter-image": "prom/statsd-exporter",
+    }
+    app_name = "flask-sentinel"
+    flask_app = await model.deploy(
+        charm, resources=resources, application_name=app_name, series="jammy"
+    )
+    await model.wait_for_idle(apps=[app_name])
+    assert flask_app.status == "blocked"
+    assert flask_app.status_message == (
+        "charm requires a Flask app image, "
+        "redeploy with '--resource flask-app-image=<your-image>'"
+    )

--- a/tests/unit/test_sentinel.py
+++ b/tests/unit/test_sentinel.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Flask charm unit tests for the sentinel module."""
+from ops.testing import Harness
+
+from constants import FLASK_CONTAINER_NAME
+from sentinel import Sentinel
+
+
+def test_sentinel(harness: Harness):
+    """
+    arrange: start the harness.
+    act: create a /null file in the flask-app container.
+    assert: sentinel check should return True after the file was added.
+    """
+    harness.begin()
+    sentinel = Sentinel(charm=harness.charm)
+    assert not sentinel.is_sentinel_image()
+    harness.model.unit.get_container(FLASK_CONTAINER_NAME).push("/null", "")
+    assert sentinel.is_sentinel_image()


### PR DESCRIPTION
The flask-k8s charm operates in the "Bring Your Own Container Image" mode, where it's expected that users provide a custom container image for their Flask application during deployment.

However, to conform to CharmHub's requirements, all resources defined in the charm metadata must be supplied during the release of the charm to CharmHub. To resolve this, a sentinel image is used as a placeholder in the charm metadata. This sentinel image does not host a Flask application but is merely used to fulfill the requirement set by CharmHub.

To accommodate the change, checks are added to the charm to detect the absence of a user-provided container image, allowing it to enter block state and provide an informative error message, guiding the user to redeploy the charm with their Flask application container image.