### PR TITLE
Rework fixtures to avoid unnecessary deployments

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -130,8 +130,10 @@ async def deploy_cos_fixture(  # pylint: disable=too-many-arguments
     loki_app_name: str,
     grafana_app_name: str,
 ):
-    """Build and deploy the cos applications."""
+    """Return a function to deploy the cos applications."""
+
     async def deploy_cos_apps():
+        """Deploy the cos applications."""
         await asyncio.gather(
             model.deploy(
                 "prometheus-k8s",
@@ -147,6 +149,7 @@ async def deploy_cos_fixture(  # pylint: disable=too-many-arguments
             ),
             model.wait_for_idle(raise_on_blocked=True),
         )
+
     return deploy_cos_apps
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,10 +105,10 @@ async def flask_app_fixture(
         "flask-app-image": pytestconfig.getoption("--flask-app-image"),
         "statsd-prometheus-exporter-image": "prom/statsd-exporter",
     }
-    app = await asyncio.gather(
-        model.deploy(build_charm, resources=resources, application_name=app_name, series="jammy"),
-        model.wait_for_idle(raise_on_blocked=True),
+    app = await model.deploy(
+        build_charm, resources=resources, application_name=app_name, series="jammy"
     )
+    await model.wait_for_idle(raise_on_blocked=True)
     return app
 
 
@@ -120,18 +120,16 @@ async def deploy_traefik_fixture(
     external_hostname: str,
 ):
     """Deploy traefik."""
-    app = await asyncio.gather(
-        model.deploy(
-            "traefik-k8s",
-            application_name=traefik_app_name,
-            trust=True,
-            config={
-                "external_hostname": external_hostname,
-                "routing_mode": "subdomain",
-            },
-        ),
-        model.wait_for_idle(raise_on_blocked=True),
+    app = await model.deploy(
+        "traefik-k8s",
+        application_name=traefik_app_name,
+        trust=True,
+        config={
+            "external_hostname": external_hostname,
+            "routing_mode": "subdomain",
+        },
     )
+    await model.wait_for_idle(raise_on_blocked=True)
 
     return app
 
@@ -142,15 +140,13 @@ async def deploy_prometheus_fixture(
     prometheus_app_name: str,
 ):
     """Deploy prometheus."""
-    app = await asyncio.gather(
-        model.deploy(
-            "prometheus-k8s",
-            application_name=prometheus_app_name,
-            channel="latest/edge",
-            trust=True,
-        ),
-        model.wait_for_idle(raise_on_blocked=True),
+    app = await model.deploy(
+        "prometheus-k8s",
+        application_name=prometheus_app_name,
+        channel="latest/edge",
+        trust=True,
     )
+    await model.wait_for_idle(raise_on_blocked=True)
 
     return app
 
@@ -161,12 +157,10 @@ async def deploy_loki_fixture(
     loki_app_name: str,
 ):
     """Deploy loki."""
-    app = await asyncio.gather(
-        model.deploy(
-            "loki-k8s", application_name=loki_app_name, channel="latest/edge", trust=True
-        ),
-        model.wait_for_idle(raise_on_blocked=True),
+    app = await model.deploy(
+        "loki-k8s", application_name=loki_app_name, channel="latest/edge", trust=True
     )
+    await model.wait_for_idle(raise_on_blocked=True)
 
     return app
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -166,6 +166,7 @@ async def test_with_ingress(
     ops_test: OpsTest,
     model: Model,
     flask_app: Application,
+    traefik_app,  # pylint: disable=unused-argument
     traefik_app_name: str,
     external_hostname: str,
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
@@ -193,7 +194,7 @@ async def test_prometheus_integration(
     model: Model,
     prometheus_app_name: str,
     flask_app: Application,
-    cos_apps,  # pylint: disable=unused-argument
+    prometheus_apps,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -214,7 +215,7 @@ async def test_loki_integration(
     model: Model,
     loki_app_name: str,
     flask_app: Application,
-    cos_apps,  # pylint: disable=unused-argument
+    loki_apps,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -193,7 +193,7 @@ async def test_prometheus_integration(
     model: Model,
     prometheus_app_name: str,
     flask_app: Application,
-    deploy_cos_apps: typing.Callable,
+    cos_apps,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -202,7 +202,6 @@ async def test_prometheus_integration(
     assert: prometheus metrics endpoint for prometheus is active and prometheus has active scrape
         targets.
     """
-    await deploy_cos_apps()
     await model.add_relation(prometheus_app_name, flask_app.name)
     await model.wait_for_idle(apps=[flask_app.name, prometheus_app_name], status="active")
 
@@ -215,7 +214,7 @@ async def test_loki_integration(
     model: Model,
     loki_app_name: str,
     flask_app: Application,
-    deploy_cos_apps: typing.Callable,
+    cos_apps,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -224,7 +223,6 @@ async def test_loki_integration(
     assert: loki joins relation successfully, logs are being output to container and to files for
         loki to scrape.
     """
-    await deploy_cos_apps()
     await model.add_relation(loki_app_name, flask_app.name)
 
     await model.wait_for_idle(
@@ -250,7 +248,7 @@ async def test_grafana_integration(
     prometheus_app_name: str,
     loki_app_name: str,
     grafana_app_name: str,
-    deploy_cos_apps: typing.Callable,
+    cos_apps,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -258,7 +256,6 @@ async def test_grafana_integration(
     act: establish relations established with grafana charm.
     assert: grafana Flask dashboard can be found.
     """
-    await deploy_cos_apps()
     await model.relate(
         f"{prometheus_app_name}:grafana-source", f"{grafana_app_name}:grafana-source"
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -194,7 +194,7 @@ async def test_prometheus_integration(
     model: Model,
     prometheus_app_name: str,
     flask_app: Application,
-    prometheus_apps,  # pylint: disable=unused-argument
+    prometheus_app,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -215,7 +215,7 @@ async def test_loki_integration(
     model: Model,
     loki_app_name: str,
     flask_app: Application,
-    loki_apps,  # pylint: disable=unused-argument
+    loki_app,  # pylint: disable=unused-argument
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -193,6 +193,7 @@ async def test_prometheus_integration(
     model: Model,
     prometheus_app_name: str,
     flask_app: Application,
+    deploy_cos_apps: typing.Callable,
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -201,6 +202,7 @@ async def test_prometheus_integration(
     assert: prometheus metrics endpoint for prometheus is active and prometheus has active scrape
         targets.
     """
+    await deploy_cos_apps()
     await model.add_relation(prometheus_app_name, flask_app.name)
     await model.wait_for_idle(apps=[flask_app.name, prometheus_app_name], status="active")
 
@@ -213,6 +215,7 @@ async def test_loki_integration(
     model: Model,
     loki_app_name: str,
     flask_app: Application,
+    deploy_cos_apps: typing.Callable,
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -221,6 +224,7 @@ async def test_loki_integration(
     assert: loki joins relation successfully, logs are being output to container and to files for
         loki to scrape.
     """
+    await deploy_cos_apps()
     await model.add_relation(loki_app_name, flask_app.name)
 
     await model.wait_for_idle(
@@ -246,6 +250,7 @@ async def test_grafana_integration(
     prometheus_app_name: str,
     loki_app_name: str,
     grafana_app_name: str,
+    deploy_cos_apps: typing.Callable,
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -253,6 +258,7 @@ async def test_grafana_integration(
     act: establish relations established with grafana charm.
     assert: grafana Flask dashboard can be found.
     """
+    await deploy_cos_apps()
     await model.relate(
         f"{prometheus_app_name}:grafana-source", f"{grafana_app_name}:grafana-source"
     )


### PR DESCRIPTION
This is a rework of the fixtures in order to avoid unnecessary deployments for some of the integration tests.  
The goal is to try to reduce the number of CI timeouts and if possible to speed things up.

The speedup seems to be real (from around 30mn to 15mn) but this will need confirmation in the long run.