### PR TITLE
Adapt integration tests to reuse the packed charm

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,6 @@
 
 def pytest_addoption(parser):
     """Define some command line options for integration and unit tests."""
+    parser.addoption("--charm-file", action="store")
     parser.addoption("--flask-app-image", action="store")
     parser.addoption("--test-flask-image", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -54,7 +54,7 @@ def grafana_app_name_fixture() -> str:
     return "grafana-k8s"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", name="charm_file")
 def charm_file_fixture(pytestconfig: pytest.Config):
     """Get the existing charm file."""
     value = pytestconfig.getoption("--charm-file")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,7 +96,7 @@ async def build_charm_fixture(charm_file: str) -> str:
     charm = "flask-k8s_ubuntu-22.04-amd64_modified.charm"
     with open(charm, "wb") as new_charm_file:
         new_charm_file.write(new_charm.getvalue())
-    return charm
+    return f"./{charm}"
 
 
 @pytest_asyncio.fixture(scope="module", name="flask_app")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,14 +55,14 @@ def grafana_app_name_fixture() -> str:
 
 
 @pytest.fixture(scope="module")
-def charm_file(pytestconfig: pytest.Config):
+def charm_file_fixture(pytestconfig: pytest.Config):
     """Get the existing charm file."""
     value = pytestconfig.getoption("--charm-file")
     yield f"./{value}"
 
 
 @pytest_asyncio.fixture(scope="module", name="build_charm")
-async def build_charm_fixture(ops_test, charm_file) -> str:
+async def build_charm_fixture(charm_file: str) -> str:
     """Build the charm and injects additional configurations into config.yaml.
 
     This fixture is designed to simulate a feature that is not yet available in charmcraft that

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,7 +62,7 @@ def charm_file(pytestconfig: pytest.Config):
 
 
 @pytest_asyncio.fixture(scope="module", name="build_charm")
-async def build_charm_fixture(ops_test) -> str:
+async def build_charm_fixture(ops_test, charm_file) -> str:
     """Build the charm and injects additional configurations into config.yaml.
 
     This fixture is designed to simulate a feature that is not yet available in charmcraft that
@@ -70,8 +70,7 @@ async def build_charm_fixture(ops_test) -> str:
     Three additional configurations, namely foo_str, foo_int, foo_dict, foo_bool,
     and application_root will be appended to the config.yaml file.
     """
-    charm = await ops_test.build_charm(".")
-    charm_zip = zipfile.ZipFile(charm, "r")
+    charm_zip = zipfile.ZipFile(charm_file, "r")
     with charm_zip.open("config.yaml") as file:
         config = yaml.safe_load(file)
     config["options"].update(
@@ -94,6 +93,7 @@ async def build_charm_fixture(ops_test) -> str:
                     data = file.read()
                 new_charm_zip.writestr(item, data)
     charm_zip.close()
+    charm = "flask-k8s_ubuntu-22.04-amd64_modified.charm"
     with open(charm, "wb") as new_charm_file:
         new_charm_file.write(new_charm.getvalue())
     return charm

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,8 +94,8 @@ async def build_charm_fixture(ops_test) -> str:
                     data = file.read()
                 new_charm_zip.writestr(item, data)
     charm_zip.close()
-    with open(charm, "wb") as charm_file:
-        charm_file.write(new_charm.getvalue())
+    with open(charm, "wb") as new_charm_file:
+        new_charm_file.write(new_charm.getvalue())
     return charm
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -54,6 +54,13 @@ def grafana_app_name_fixture() -> str:
     return "grafana-k8s"
 
 
+@pytest.fixture(scope="module")
+def charm_file(pytestconfig: pytest.Config):
+    """Get the existing charm file."""
+    value = pytestconfig.getoption("--charm-file")
+    yield f"./{value}"
+
+
 @pytest_asyncio.fixture(scope="module", name="build_charm")
 async def build_charm_fixture(ops_test) -> str:
     """Build the charm and injects additional configurations into config.yaml.

--- a/tests/integration/test_default.py
+++ b/tests/integration/test_default.py
@@ -13,7 +13,6 @@ from pytest_operator.plugin import OpsTest
 
 async def test_default_image(
     pytestconfig: Config,
-    ops_test: OpsTest,
     model: Model,
     charm_file: str,
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],

--- a/tests/integration/test_default.py
+++ b/tests/integration/test_default.py
@@ -15,6 +15,7 @@ async def test_default_image(
     pytestconfig: Config,
     ops_test: OpsTest,
     model: Model,
+    charm_file: str,
     get_unit_ips: typing.Callable[[str], typing.Awaitable[tuple[str, ...]]],
 ):
     """
@@ -22,13 +23,12 @@ async def test_default_image(
     act: build and deploy the flask-k8s charm with default image as the flask-app-image.
     assert: flask-k8s charm should run the default Flask application.
     """
-    charm = await ops_test.build_charm(".")
     resources = {
         "flask-app-image": pytestconfig.getoption("--flask-app-image"),
         "statsd-prometheus-exporter-image": "prom/statsd-exporter",
     }
     app_name = "flask-sentinel"
-    await model.deploy(charm, resources=resources, application_name=app_name, series="jammy")
+    await model.deploy(charm_file, resources=resources, application_name=app_name, series="jammy")
     await model.wait_for_idle(apps=[app_name], raise_on_blocked=True)
     for unit_ip in await get_unit_ips(app_name):
         resp = requests.get(f"http://{unit_ip}:8000", timeout=10)

--- a/tests/integration/test_default.py
+++ b/tests/integration/test_default.py
@@ -8,7 +8,6 @@ import typing
 import requests
 from juju.model import Model
 from pytest import Config
-from pytest_operator.plugin import OpsTest
 
 
 async def test_default_image(

--- a/tox.ini
+++ b/tox.ini
@@ -118,4 +118,4 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/integration/requirements.txt
 commands =
-    pytest {[vars]tst_path} -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Adapt the integration tests to reuse the exisintg charm artifact as per https://github.com/canonical/operator-workflows/pull/162