### PR TITLE
Change the service from flask-app to flask

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -81,6 +81,7 @@ class FlaskCharm(ops.CharmBase):
         self.framework.observe(
             self.on.secret_storage_relation_changed, self._on_secret_storage_relation_changed
         )
+        self.framework.observe(self.on.flask_app_pebble_ready, self._on_flask_app_pebble_ready)
 
     def _on_config_changed(self, _event: ops.EventBase) -> None:
         """Configure the flask pebble service layer.
@@ -136,6 +137,10 @@ class FlaskCharm(ops.CharmBase):
         """Handle the update-status event."""
         if self._database_migration.get_status() == DatabaseMigrationStatus.FAILED:
             self._restart_flask()
+
+    def _on_flask_app_pebble_ready(self, _: ops.PebbleReadyEvent) -> None:
+        """Handle the pebble-ready event."""
+        self._restart_flask()
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,7 +6,7 @@
 import pathlib
 
 FLASK_CONTAINER_NAME = "flask-app"
-FLASK_SERVICE_NAME = "flask-app"
+FLASK_SERVICE_NAME = "flask"
 FLASK_ENV_CONFIG_PREFIX = "FLASK_"
 FLASK_DATABASE_NAME = "flask-app"
 FLASK_SUPPORTED_DB_INTERFACES = {"mysql_client": "mysql", "postgresql_client": "postgresql"}

--- a/src/flask_app.py
+++ b/src/flask_app.py
@@ -108,7 +108,7 @@ class FlaskApp:  # pylint: disable=too-few-public-methods
         if not self._charm_state.is_secret_storage_ready:
             logger.info("secret storage is not initialized")
             return
-        container.add_layer("flask-app", self._flask_layer(), combine=True)
+        container.add_layer("flask", self._flask_layer(), combine=True)
         is_webserver_running = container.get_service(FLASK_SERVICE_NAME).is_running()
         self._webserver.update_config(
             flask_environment=self._flask_environment(),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,7 +12,7 @@ import yaml
 from ops.testing import Harness
 
 from charm_state import KNOWN_CHARM_CONFIG, CharmState
-from constants import FLASK_CONTAINER_NAME
+from constants import FLASK_CONTAINER_NAME, FLASK_SERVICE_NAME
 from flask_app import FlaskApp
 from webserver import GunicornWebserver
 
@@ -44,7 +44,8 @@ def test_flask_pebble_layer(harness: Harness) -> None:
         database_migration=harness.charm._database_migration,
     )
     flask_app.restart_flask()
-    flask_layer = harness.get_container_pebble_plan("flask-app").to_dict()["services"]["flask-app"]
+    plan = harness.get_container_pebble_plan(FLASK_CONTAINER_NAME)
+    flask_layer = plan.to_dict()["services"][FLASK_SERVICE_NAME]
     assert flask_layer == {
         "override": "replace",
         "summary": "Flask application service",


### PR DESCRIPTION
### Overview

Rename the Pebble service from `flask-app` to `flask`.

### Rationale

Within the rockcraft project file, the `services` defined are carried over to the charm. Upon invoking `pebble.replan`, the `services` specified in the rockcraft project file will start as well. Renaming the service from `flask-app` to `flask` to align with the `flask-framework` extension, and ensure the charm can overwrite the service.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
