### PR TITLE
Fix the error log when database migration failed

### DIFF
--- a/src/database_migration.py
+++ b/src/database_migration.py
@@ -115,7 +115,7 @@ class DatabaseMigration:
                 ["/bin/bash", "-xeo", "pipefail", self.script],
                 environment=environment,
                 working_dir=str(FLASK_APP_DIR),
-            ).wait()
+            ).wait_output()
             self._set_status(DatabaseMigrationStatus.COMPLETED)
             self._set_completed_script(self.script)
         except ExecError as exc:


### PR DESCRIPTION
### Overview

The present database migration module uses `ExecProcess.wait` rather than `ExecProcess.wait_output` to run the database migration script. However, `ExecProcess.wait` does not provide stdout and stderr output. As a result, the charm cannot log error messages if the database migration failed.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
